### PR TITLE
Added fuel to limit CPU time

### DIFF
--- a/sandboxed-plugin-runner/src/main.rs
+++ b/sandboxed-plugin-runner/src/main.rs
@@ -55,6 +55,9 @@ fn main() -> anyhow::Result<()> {
                 }
             };
 
+            //resetting the fuel for this plugin
+            store.add_fuel(1_000_000)?; //need to check fuel units value (what is most optimal) 
+
             //instantiating the WASM module using the linker
             let instance = match linker.instantiate(&mut store, &module) {
                 //if instantiation is successful, store the resulting instance in `plugin_instance`


### PR DESCRIPTION
Added fuel to limit CPU time line to the sandbox runner, main.rs. Currently: 1_000_000
Check whether to increase or decrease. Test multiple times to be sure.
Also, measure the fuel consumed after the runs.