### PR TITLE
Add WASI Context for Isolated Plugin Execution

### DIFF
--- a/sandboxed-plugin-runner/src/main.rs
+++ b/sandboxed-plugin-runner/src/main.rs
@@ -58,6 +58,11 @@ fn main() -> anyhow::Result<()> {
             //resetting the fuel for this plugin
             store.add_fuel(1_000_000)?; //need to check fuel units value (what is most optimal) 
 
+            //building a fresh WASI sandbox
+            let wasi = WasiCtxBuilder::new().build();
+            //attaching it to the store for isolated execution
+            store.set_wasi(wasi);
+
             //instantiating the WASM module using the linker
             let instance = match linker.instantiate(&mut store, &module) {
                 //if instantiation is successful, store the resulting instance in `plugin_instance`


### PR DESCRIPTION
This PR introduces a new WASI context to the Wasmtime Store in order to provide isolated execution for WASM plugins.

WasiCtxBuilder::new().build() creates a clean, isolated sandbox environment for the plugin, with no access to the host files, network, or environment by default.
store.set_wasi(wasi) will then attach that sandbox to the plugin’s execution so it runs safely inside its own contained system instead of touching local machine.

WASI provides a sandboxed environment for plugin execution, preventing plugins from interacting directly with the host OS. This strengthens the overall security, ensures consistent behavior across runs, and supports safe memory isolation. Confirmed no host filesystem or environment access unless explicitly configured.