### PR TITLE
Check that the plugins/folder exists and check that the channel to receive the file is set up correctly

### DIFF
--- a/sandboxed-plugin-runner/src/main.rs
+++ b/sandboxed-plugin-runner/src/main.rs
@@ -40,8 +40,13 @@ fn main() -> anyhow::Result<()> {
         }
     })?;
 
-    //dynamically loading the plugins
-    let modules_path = "plugins/";
+    //a folder to watch for the plugins
+    let plugin_folder = PathBuf::from("plugins/");
+    //checking to make sure it exists
+    fs::create_dir_all(&plugin_folder)?; 
+    //channel for watching the folder
+    let (tx, rx) = channel();
+    
     //defining the folder path (plugins/) where the WebAssembly plugin files are stored
     for entry in fs::read_dir(modules_path)? {
         /*reading all entries


### PR DESCRIPTION
The code I added to the trisha-plugin-reload branch sets up the infrastructure for dynamic plugin loading by defining the plugins/ directory as a filesystem path and this ensures that the directory exists by creating it if necessary, establishing a message-passing channel whose sender will be used to emit filesystem change events, while the receiver allows the program to listen for and respond to those plugin folder changes at runtime.


Check and then merge to main!