### PR TITLE
Function to scan the folder and run all .wasm plugins

### DIFF
--- a/sandboxed-plugin-runner/src/main.rs
+++ b/sandboxed-plugin-runner/src/main.rs
@@ -73,6 +73,11 @@ fn main() -> anyhow::Result<()> {
 fn scan_and_run_plugins(engine: &Engine, store: &mut Store<()>, linker: &Linker<()>, folder: &PathBuf) -> Result<()> {
     for entry in fs::read_dir(folder)? {
         let path = entry?.path();
+
+        //to make sure to only load .wasm files
+        if path.extension().map(|ext| ext == "wasm").unwrap_or(false) {
+            let plugin_name = path.file_name().unwrap().to_string_lossy();
+            println!("Loading plugin: {}", plugin_name);
     
     //defining the folder path (plugins/) where the WebAssembly plugin files are stored
     for entry in fs::read_dir(modules_path)? {


### PR DESCRIPTION
Function to scan the folder and run all .wasm plugins

then, only loaded .wasm files and the wasm module in branch trisha-func-scan-and-run. Merge to main.