### PR TITLE
Erase duplicate code

### DIFF
--- a/sandboxed-plugin-runner/src/main.rs
+++ b/sandboxed-plugin-runner/src/main.rs
@@ -71,13 +71,6 @@ fn main() -> anyhow::Result<()> {
 
 //a function to scan the folder and run all the .wasm plugins
 fn scan_and_run_plugins(engine: &Engine, store: &mut Store<()>, linker: &Linker<()>, folder: &PathBuf) -> Result<()> {
-    for entry in fs::read_dir(folder)? {
-        let path = entry?.path();
-
-        //to make sure to only load .wasm files
-        if path.extension().map(|ext| ext == "wasm").unwrap_or(false) {
-            let plugin_name = path.file_name().unwrap().to_string_lossy();
-            println!("Loading plugin: {}", plugin_name);
     
     //defining the folder path (plugins/) where the WebAssembly plugin files are stored
     for entry in fs::read_dir(modules_path)? {


### PR DESCRIPTION
Starting on Lines 74 - 80, then from lines 83 - 91, there is duplicate for loop code. I had written it before to test the for loops with the new function scan_and_run_plugins when I could have used the previous code. Remove, merge changes.